### PR TITLE
Add default ttl to table definition

### DIFF
--- a/phantom-dsl/src/main/scala/com/websudos/phantom/CassandraTable.scala
+++ b/phantom-dsl/src/main/scala/com/websudos/phantom/CassandraTable.scala
@@ -22,6 +22,7 @@ import scala.reflect.runtime.{currentMirror => cm, universe => ru}
 import scala.util.Try
 
 import org.slf4j.LoggerFactory
+import org.joda.time.Seconds
 
 import com.datastax.driver.core.{Session, Row}
 import com.datastax.driver.core.querybuilder.QueryBuilder
@@ -32,6 +33,8 @@ import com.websudos.phantom.column.AbstractColumn
 import com.websudos.phantom.query.{CreateQuery, DeleteQuery, InsertQuery, SelectCountQuery, TruncateQuery, UpdateQuery}
 
 case class InvalidPrimaryKeyException(msg: String = "You need to define at least one PartitionKey for the schema") extends RuntimeException(msg)
+
+case class InvalidTableException(msg: String) extends RuntimeException(msg)
 
 abstract class CassandraTable[T <: CassandraTable[T, R], R] extends SelectTable[T, R] {
 
@@ -79,6 +82,8 @@ abstract class CassandraTable[T <: CassandraTable[T, R], R] extends SelectTable[
   def clusteringColumns: Seq[AbstractColumn[_]] = columns.filter(_.isClusteringKey)
 
   def clustered: Boolean = clusteringColumns.nonEmpty
+
+  def defaultTTL: Option[Seconds] = None
 
   /**
    * This method will filter the columns from a Clustering Order definition.
@@ -171,7 +176,20 @@ abstract class CassandraTable[T <: CassandraTable[T, R], R] extends SelectTable[
     }
   }
 
+  private[phantom] def ttlClause: String = {    
+    defaultTTL.map{ ttl => 
+      if (columns.exists(_.isCounterColumn)) {
+        val msg = "When setting a default ttl, the table cannot contain any counting columns"
+        logger.error(msg)
+        throw new InvalidTableException(msg)
+      }
+      val kw = if (clustered) "AND" else "WITH"
+      kw + " default_time_to_live=" + ttl.getSeconds
+    }.getOrElse("")
+  }
+
   @throws[InvalidPrimaryKeyException]
+  @throws[InvalidTableException]
   def schema(): String = {
     preconditions()
 
@@ -188,7 +206,7 @@ abstract class CassandraTable[T <: CassandraTable[T, R], R] extends SelectTable[
     val queryPrimaryKey  = if (tableKey.length > 0) s", $tableKey" else ""
 
     val query = queryInit + queryColumns.drop(1) + queryPrimaryKey + ")"
-    val finalQuery = query + clusteringKey
+    val finalQuery = query + clusteringKey + ttlClause
     if (finalQuery.last != ';') finalQuery + ";" else finalQuery
   }
 

--- a/phantom-dsl/src/test/scala/com/websudos/phantom/TableKeyGenerationTest.scala
+++ b/phantom-dsl/src/test/scala/com/websudos/phantom/TableKeyGenerationTest.scala
@@ -2,7 +2,7 @@ package com.websudos.phantom
 
 import org.scalatest.{FlatSpec, Matchers, ParallelTestExecution}
 
-import com.websudos.phantom.tables.{BrokenClusteringTable, TableWithCompositeKey, TableWithCompoundKey, TableWithNoKey, TableWithSingleKey}
+import com.websudos.phantom.tables.{BrokenClusteringTable, TableWithCompositeKey, TableWithCompoundKey, TableWithNoKey, TableWithSingleKey, TimeSeriesTableWithTTL, BrokenCounterTableTest, TimeSeriesTableWithTTL2}
 
 class TableKeyGenerationTest extends FlatSpec with Matchers with ParallelTestExecution {
 
@@ -18,6 +18,15 @@ class TableKeyGenerationTest extends FlatSpec with Matchers with ParallelTestExe
     TableWithCompositeKey.defineTableKey() shouldEqual s"PRIMARY KEY ((id, second_part), second)"
   }
 
+  it should "correctly create a Table with TTL with Clustering" in {
+    TimeSeriesTableWithTTL.ttlClause shouldEqual s"AND default_time_to_live=5"
+  }
+
+  it should "correctly create a Table with TTL" in {
+    TimeSeriesTableWithTTL2.ttlClause shouldEqual s"WITH default_time_to_live=5"
+  }
+
+
   it should "throw an error if the schema has no PartitionKey" in {
     intercept[InvalidPrimaryKeyException] {
       TableWithNoKey.defineTableKey()
@@ -30,4 +39,9 @@ class TableKeyGenerationTest extends FlatSpec with Matchers with ParallelTestExe
     }
   }
 
+  it should "throw an error if the table uses TTLs with CounterColumns" in {
+    intercept[InvalidTableException] {
+      BrokenCounterTableTest.ttlClause
+    }
+  }
 }

--- a/phantom-dsl/src/test/scala/com/websudos/phantom/tables/CounterTableTest.scala
+++ b/phantom-dsl/src/test/scala/com/websudos/phantom/tables/CounterTableTest.scala
@@ -48,3 +48,20 @@ class SecondaryCounterTable extends CassandraTable[SecondaryCounterTable, Counte
 object SecondaryCounterTable extends SecondaryCounterTable with PhantomCassandraConnector {
   override val tableName = "secondary_column_tests"
 }
+
+class BrokenCounterTableTest extends CassandraTable[BrokenCounterTableTest, CounterRecord] {
+
+  object id extends UUIDColumn(this) with PartitionKey[UUID]
+  object count_entries extends CounterColumn(this)
+
+  def fromRow(row: Row): CounterRecord = {
+    CounterRecord(id(row), count_entries(row))
+  }
+
+  override def defaultTTL = Some(org.joda.time.Seconds.seconds(5))
+}
+
+object BrokenCounterTableTest extends BrokenCounterTableTest with PhantomCassandraConnector {
+  override val tableName = "counter_column_tests"
+}
+

--- a/phantom-dsl/src/test/scala/com/websudos/phantom/tables/TimeSeriesTableWithTTL.scala
+++ b/phantom-dsl/src/test/scala/com/websudos/phantom/tables/TimeSeriesTableWithTTL.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2013 websudos ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.websudos.phantom.tables
+
+import java.util.UUID
+
+import org.joda.time.{DateTime, Seconds}
+
+import com.websudos.phantom.Implicits._
+import com.websudos.phantom.PhantomCassandraConnector
+import com.websudos.util.testing._
+
+
+sealed class TimeSeriesTableWithTTL extends CassandraTable[TimeSeriesTableWithTTL, TimeSeriesRecord] {
+  object id extends UUIDColumn(this) with PartitionKey[UUID]
+  object name extends StringColumn(this)
+  object timestamp extends DateTimeColumn(this) with ClusteringOrder[DateTime] with Descending
+
+  override def defaultTTL = Some(Seconds.seconds(5))
+
+  def fromRow(row: Row): TimeSeriesRecord = {
+    TimeSeriesRecord(
+      id(row),
+      name(row),
+      timestamp(row)
+    )
+  }
+}
+
+object TimeSeriesTableWithTTL extends TimeSeriesTableWithTTL with PhantomCassandraConnector {
+  val testUUID = gen[UUID]
+}
+
+sealed class TimeSeriesTableWithTTL2 extends CassandraTable[TimeSeriesTableWithTTL2, TimeSeriesRecord] {
+  object id extends UUIDColumn(this) with PartitionKey[UUID]
+  object name extends StringColumn(this)
+  object timestamp extends DateTimeColumn(this)
+
+  override def defaultTTL = Some(Seconds.seconds(5))
+
+  def fromRow(row: Row): TimeSeriesRecord = {
+    TimeSeriesRecord(
+      id(row),
+      name(row),
+      timestamp(row)
+    )
+  }
+}
+
+object TimeSeriesTableWithTTL2 extends TimeSeriesTableWithTTL2 with PhantomCassandraConnector {
+  val testUUID = gen[UUID]
+}
+


### PR DESCRIPTION
Cassandra supports a default time to live for a given table that does not contain counters.

I have used joda time Seconds, this might of course be changed if that makes sense. We could instead maybe use an own TTL class, which can convert from joda.time.Period, or even scala.concurrent.Duration. Please discuss.