### PR TITLE
Bump DataStax Java Driver to v2.1.4

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -7,7 +7,7 @@ import scoverage.ScoverageSbtPlugin.instrumentSettings
 object phantom extends Build {
 
   val UtilVersion = "0.5.0"
-  val DatastaxDriverVersion = "2.1.1"
+  val DatastaxDriverVersion = "2.1.4"
   val ScalaTestVersion = "2.2.1"
   val FinagleVersion = "6.24.0"
   val TwitterUtilVersion = "6.23.0"
@@ -221,7 +221,7 @@ object phantom extends Build {
       "com.twitter"                  %% "finagle-serversets"                % FinagleVersion exclude("org.slf4j", "slf4j-jdk14"),
       "com.twitter"                  %% "finagle-zookeeper"                 % FinagleVersion,
       "com.websudos"                 %% "util-testing"                      % UtilVersion            % "test, provided",
-      "org.cassandraunit"            %  "cassandra-unit"                    % "2.0.2.4"              % "test, provided"  excludeAll(
+      "org.cassandraunit"            %  "cassandra-unit"                    % "2.0.2.2"              % "test, provided"  excludeAll(
         ExclusionRule("org.slf4j", "slf4j-log4j12"),
         ExclusionRule("org.slf4j", "slf4j-jdk14")
       )
@@ -240,7 +240,7 @@ object phantom extends Build {
       "org.scalacheck"                   %% "scalacheck"               % "1.11.3"              % "test",
       "com.twitter"                      %% "finagle-serversets"       % FinagleVersion,
       "com.twitter"                      %% "finagle-zookeeper"        % FinagleVersion,
-      "org.cassandraunit"                %  "cassandra-unit"           % "2.0.2.4"  excludeAll (
+      "org.cassandraunit"                %  "cassandra-unit"           % "2.0.2.2"  excludeAll (
         ExclusionRule("org.slf4j", "slf4j-log4j12"),
         ExclusionRule("org.slf4j", "slf4j-jdk14")
       )


### PR DESCRIPTION
Currently Phantom depends on driver version 2.1.1, and a great amount of bugs have been fixed since then, some of them even critical for production environment (https://datastax-oss.atlassian.net/browse/JAVA-476). It would be nice to upgrade the version to make phantom more stable.

I have also lowered cassandra-unit version to 2.0.2.2, I have found that it is an unresolved dependency (does not exist on maven central), and discovered that this is also the reason of the other PRs failed build (cf. TravisCI)

I have managed to run the test suite locally, only phantom-thrift doesn't compile and couldn't fix because:
> phantom/phantom-thrift/src/test/scala/com/websudos/phantom/thrift/ThriftMapColumnTest.scala:41: object Sampler in package testing cannot be accessed in package com.websudos.util.testing