### PR TITLE
Select Distinct

### DIFF
--- a/phantom-dsl/src/main/scala/com/websudos/phantom/SelectTable.scala
+++ b/phantom-dsl/src/main/scala/com/websudos/phantom/SelectTable.scala
@@ -243,7 +243,7 @@ trait SelectTable[T <: CassandraTable[T, R], R] {
   def distinct[A](f1: T => SelectColumn[A]): SelectQuery[T, A] = {
     val t = this.asInstanceOf[T]
     val c = f1(t)
-    new SelectQuery[T, A](t, QueryBuilder.select.distinct().from(tableName), c.apply)
+    new SelectQuery[T, A](t, QueryBuilder.select.column(c.col.name).distinct().from(tableName), c.apply)
   }
 
 }


### PR DESCRIPTION
`distinct(_.{partitionKey})` now produces `SELECT DISTINCT {partitionKey} FROM {table};` instead of (invalid) `SELECT DISTINCT * FROM {table}`