### PR TITLE
Release/dbs

### DIFF
--- a/phantom-dsl/src/main/scala/com/websudos/phantom/builder/ops/QueryColumn.scala
+++ b/phantom-dsl/src/main/scala/com/websudos/phantom/builder/ops/QueryColumn.scala
@@ -51,7 +51,7 @@ sealed class QueryColumn[RR : Primitive](val col: AbstractColumn[RR]) {
     new WhereClause.Condition(QueryBuilder.Where.eqs(col.name, p.asCql(value)))
   }
 
-  def eqs(value: PrepareMark): WhereClause.Condition = {
+  final def eqs(value: PrepareMark): WhereClause.Condition = {
     new WhereClause.Condition(QueryBuilder.Where.eqs(col.name, value.symbol))
   }
 

--- a/phantom-dsl/src/main/scala/com/websudos/phantom/db/DatabaseImpl.scala
+++ b/phantom-dsl/src/main/scala/com/websudos/phantom/db/DatabaseImpl.scala
@@ -1,0 +1,62 @@
+package com.websudos.phantom.db
+
+import com.datastax.driver.core.Session
+import com.websudos.phantom.CassandraTable
+import com.websudos.phantom.builder.query.ExecutableStatementList
+import com.websudos.phantom.connectors.{KeySpace, KeySpaceDef}
+
+import scala.collection.mutable.{ArrayBuffer => MutableArrayBuffer}
+import scala.reflect.runtime.universe.Symbol
+import scala.reflect.runtime.{currentMirror => cm, universe => ru}
+
+private object Lock
+
+abstract class DatabaseImpl(protected[this] val connector: KeySpaceDef) {
+
+  private[this] lazy val _tables: MutableArrayBuffer[CassandraTable[_, _]] = new MutableArrayBuffer[CassandraTable[_, _]]
+
+  implicit val space: KeySpace = new KeySpace(connector.name)
+
+  implicit lazy val session: Session = connector.session
+
+  def tables: Set[CassandraTable[_, _]] = _tables.toSet
+
+  Lock.synchronized {
+
+    val instanceMirror = cm.reflect(this)
+    val selfType = instanceMirror.symbol.toType
+
+    // Collect all column definitions starting from base class
+    val columnMembers = MutableArrayBuffer.empty[Symbol]
+    selfType.baseClasses.reverse.foreach {
+      baseClass =>
+        val baseClassMembers = baseClass.typeSignature.members.sorted
+        val baseClassColumns = baseClassMembers.filter(_.typeSignature <:< ru.typeOf[CassandraTable[_, _]])
+        baseClassColumns.foreach(symbol => if (!columnMembers.contains(symbol)) columnMembers += symbol)
+    }
+
+    columnMembers.foreach {
+      symbol =>
+        val table =  if (symbol.isModule) {
+          instanceMirror.reflectModule(symbol.asModule).instance
+        } else {
+          instanceMirror.reflectModule(symbol.asModule).symbol
+        }
+        _tables += table.asInstanceOf[CassandraTable[_, _]]
+    }
+  }
+
+  def autocreate(): ExecutableStatementList = {
+    new ExecutableStatementList(_tables.toSeq.map {
+      table => table.create.ifNotExists().qb
+    })
+  }
+
+  def autotruncate(): ExecutableStatementList = {
+    new ExecutableStatementList(_tables.toSeq.map {
+      table => table.truncate().qb
+    })
+  }
+}
+
+

--- a/phantom-dsl/src/main/scala/com/websudos/phantom/dsl/package.scala
+++ b/phantom-dsl/src/main/scala/com/websudos/phantom/dsl/package.scala
@@ -104,6 +104,7 @@ package object dsl extends ImplicitMechanism with CreateImplicits with DefaultPr
   type StaticColumn[ValueType] = com.websudos.phantom.keys.StaticColumn[ValueType]
 
   type SimpleCassandraConnector = com.websudos.phantom.connectors.SimpleConnector
+  type Databsae = com.websudos.phantom.db.DatabaseImpl
 
   type DateTime = org.joda.time.DateTime
   type DateTimeZone = org.joda.time.DateTimeZone
@@ -204,6 +205,7 @@ package object dsl extends ImplicitMechanism with CreateImplicits with DefaultPr
   implicit class RichNumber(val percent: Int) extends AnyVal {
     def percentile: CQLQuery = CQLQuery(percent.toString).append(CQLSyntax.CreateOptions.percentile)
   }
+
 
   implicit lazy val context = Manager.scalaExecutor
 

--- a/phantom-dsl/src/test/scala/com/websudos/phantom/db/DatabaseImplTest.scala
+++ b/phantom-dsl/src/test/scala/com/websudos/phantom/db/DatabaseImplTest.scala
@@ -1,0 +1,21 @@
+package com.websudos.phantom.db
+
+import com.websudos.phantom.dsl._
+import com.websudos.phantom.testkit.suites.PhantomCassandraTestSuite
+import com.websudos.util.testing._
+
+class DatabaseImplTest extends PhantomCassandraTestSuite {
+  val db = new TestDatabase
+
+  it should "instantiate a database and collect references to the tables" in {
+    db.tables.size shouldEqual 4
+  }
+
+  it should "automatically generate the CQL schema and initialise tables " in {
+    db.autocreate().future().successful {
+      res => {
+        res.nonEmpty shouldEqual true
+      }
+    }
+  }
+}

--- a/phantom-dsl/src/test/scala/com/websudos/phantom/db/TestDatabase.scala
+++ b/phantom-dsl/src/test/scala/com/websudos/phantom/db/TestDatabase.scala
@@ -1,0 +1,16 @@
+package com.websudos.phantom.db
+
+import com.websudos.phantom.connectors.ContactPoint
+import com.websudos.phantom.tables.{Recipes, JsonTable, EnumTable, BasicTable}
+
+
+private object DefaultKeysapce {
+  lazy val local = ContactPoint.local.keySpace("phantom_test")
+}
+
+class TestDatabase extends DatabaseImpl(DefaultKeysapce.local) {
+  object basicTable extends BasicTable with connector.Connector
+  object enumTable extends EnumTable with connector.Connector
+  object jsonTable extends JsonTable with connector.Connector
+  object recipes extends Recipes with connector.Connector
+}

--- a/phantom-dsl/src/test/scala/com/websudos/phantom/tables/BasicTable.scala
+++ b/phantom-dsl/src/test/scala/com/websudos/phantom/tables/BasicTable.scala
@@ -32,7 +32,7 @@ package com.websudos.phantom.tables
 import com.websudos.phantom.dsl._
 import com.websudos.phantom.testkit._
 
-sealed class BasicTable extends CassandraTable[BasicTable, String] {
+class BasicTable extends CassandraTable[BasicTable, String] {
 
   object id extends UUIDColumn(this) with PartitionKey[UUID]
   object id2 extends UUIDColumn(this) with PrimaryKey[UUID]
@@ -70,7 +70,7 @@ case class NamedEnumRecord(
   optEnum: Option[NamedRecords.type#Value]
 )
 
-sealed class EnumTable extends CassandraTable[EnumTable, EnumRecord] {
+class EnumTable extends CassandraTable[EnumTable, EnumRecord] {
   object id extends StringColumn(this) with PartitionKey[String]
   object enum extends EnumColumn[EnumTable, EnumRecord, Records.type](this, Records)
   object optEnum extends OptionalEnumColumn[EnumTable, EnumRecord, Records.type](this, Records)

--- a/phantom-dsl/src/test/scala/com/websudos/phantom/tables/Recipes.scala
+++ b/phantom-dsl/src/test/scala/com/websudos/phantom/tables/Recipes.scala
@@ -44,7 +44,7 @@ case class Recipe(
   uid: UUID
 )
 
-sealed class Recipes extends CassandraTable[Recipes, Recipe] {
+class Recipes extends CassandraTable[Recipes, Recipe] {
 
   object url extends StringColumn(this) with PartitionKey[String]
 

--- a/project/PhantomBuild.scala
+++ b/project/PhantomBuild.scala
@@ -46,7 +46,6 @@ object PhantomBuild extends Build {
   val PlayVersion = "2.4.0-M1"
   val Json4SVersion = "3.2.11"
   val ScalaMeterVersion = "0.6"
-  val CassandraUnitVersion = "2.1.3.2"
   val SparkCassandraVersion = "1.2.0-alpha3"
   val ThriftVersion = "0.5.0"
   val PhantomSbtVersion = "1.9.3"
@@ -103,7 +102,7 @@ object PhantomBuild extends Build {
 
   val sharedSettings: Seq[Def.Setting[_]] = Defaults.coreDefaultSettings ++ Seq(
     organization := "com.websudos",
-    version := "1.9.10-SNAPSHOT",
+    version := "1.10.1",
     scalaVersion := "2.11.6",
     crossScalaVersions := Seq("2.10.5", "2.11.6"),
     resolvers ++= Seq(
@@ -135,8 +134,7 @@ object PhantomBuild extends Build {
     testOptions in Test := Seq(Tests.Filter(x => !performanceFilter(x))),
     testOptions in PerformanceTest := Seq(Tests.Filter(x => performanceFilter(x))),
     fork in PerformanceTest := true
-  ) ++ net.virtualvoid.sbt.graph.Plugin.graphSettings ++ publishSettings ++
-    StandardProject.newSettings
+  ) ++ net.virtualvoid.sbt.graph.Plugin.graphSettings ++ mavenPublishSettings ++ StandardProject.newSettings
 
 
   lazy val phantom = Project(
@@ -154,7 +152,6 @@ object PhantomBuild extends Build {
     phantomExample,
     phantomConnectors,
     // phantomScalatraTest,
-    phantomSbtPlugin,
     phantomTestKit,
     phantomThrift,
     phantomUdt,
@@ -320,24 +317,5 @@ object PhantomBuild extends Build {
     phantomThrift,
     phantomZookeeper,
     phantomTestKit
-  )
-
-  lazy val phantomSbtPlugin = Project(
-    id = "phantom-sbt",
-    base = file("phantom-sbt"),
-    settings = Defaults.coreDefaultSettings ++ sharedSettings
-  ).settings(
-    name := "phantom-sbt",
-    scalaVersion := "2.10.5",
-    sbtPlugin := true,
-    resolvers ++= Seq(
-      Resolver.bintrayRepo("websudos", "oss-releases")
-    ),
-    libraryDependencies ++= Seq(
-      "org.cassandraunit" % "cassandra-unit"  % CassandraUnitVersion  excludeAll (
-        ExclusionRule("org.slf4j", "slf4j-log4j12"),
-        ExclusionRule("org.slf4j", "slf4j-jdk14")
-      )
-    )
   )
 }


### PR DESCRIPTION
- Removed the `phantom-sbt` module from the default Phantom build and moved to a separate repository for controlled publishing.
- Removed concrete implementation of query primitives from phantom and using `diesel-engine` for query operations and multi-part queries.
- Added a simple `DatabaseImpl` table reference collector inspired by the `phantom-enterprise` version to simplify flow control when defining full databases.