### PR TITLE
Re-adding ability to specify consistency levels at query level for CQ…

### DIFF
--- a/phantom-dsl/src/main/scala/com/websudos/phantom/builder/query/CassandraOperations.scala
+++ b/phantom-dsl/src/main/scala/com/websudos/phantom/builder/query/CassandraOperations.scala
@@ -29,7 +29,7 @@
  */
 package com.websudos.phantom.builder.query
 
-import com.datastax.driver.core.{ResultSet, Session}
+import com.datastax.driver.core.{ResultSet, Session, Statement}
 import com.google.common.util.concurrent.{FutureCallback, Futures}
 import com.twitter.util.{Future => TwitterFuture, Promise => TwitterPromise, Return, Throw}
 import com.websudos.phantom.Manager
@@ -40,16 +40,16 @@ import scala.util.{Failure, Success}
 
 private[phantom] trait CassandraOperations {
 
-  protected[this] def scalaQueryStringExecuteToFuture(query: String)(implicit session: Session, keyspace: KeySpace): ScalaFuture[ResultSet] = {
-    scalaQueryStringToPromise(query).future
+  protected[this] def scalaQueryStringExecuteToFuture(st: Statement)(implicit session: Session, keyspace: KeySpace): ScalaFuture[ResultSet] = {
+    scalaQueryStringToPromise(st).future
   }
 
-  protected[this] def scalaQueryStringToPromise(query: String)(implicit session: Session, keyspace: KeySpace): ScalaPromise[ResultSet] = {
-    Manager.logger.debug(s"Executing query: $query")
+  protected[this] def scalaQueryStringToPromise(st: Statement)(implicit session: Session, keyspace: KeySpace): ScalaPromise[ResultSet] = {
+    Manager.logger.debug(s"Executing query: ${st}")
 
     val promise = ScalaPromise[ResultSet]()
 
-    val future = session.executeAsync(query)
+    val future = session.executeAsync(st)
 
     val callback = new FutureCallback[ResultSet] {
       def onSuccess(result: ResultSet): Unit = {
@@ -66,9 +66,9 @@ private[phantom] trait CassandraOperations {
   }
 
 
-  protected[this] def twitterQueryStringExecuteToFuture(query: String)(implicit session: Session, keyspace: KeySpace): TwitterFuture[ResultSet] = {
+  protected[this] def twitterQueryStringExecuteToFuture(str: Statement)(implicit session: Session, keyspace: KeySpace): TwitterFuture[ResultSet] = {
     val promise = TwitterPromise[ResultSet]()
-    val future = session.executeAsync(query)
+    val future = session.executeAsync(str)
 
     val callback = new FutureCallback[ResultSet] {
       def onSuccess(result: ResultSet): Unit = {

--- a/phantom-dsl/src/main/scala/com/websudos/phantom/builder/query/DeleteQuery.scala
+++ b/phantom-dsl/src/main/scala/com/websudos/phantom/builder/query/DeleteQuery.scala
@@ -29,7 +29,7 @@
  */
 package com.websudos.phantom.builder.query
 
-import com.datastax.driver.core.Row
+import com.datastax.driver.core.{ConsistencyLevel, Row}
 import com.websudos.phantom.CassandraTable
 import com.websudos.phantom.builder._
 import com.websudos.phantom.builder.clauses.{CompareAndSetClause, WhereClause}
@@ -47,8 +47,9 @@ class DeleteQuery[
 ](table: Table,
   init: CQLQuery,
   wherePart : WherePart = Defaults.EmptyWherePart,
-  casPart : CompareAndSetPart = Defaults.EmptyCompareAndSetPart
-                    ) extends Query[Table, Record, Limit, Order, Status, Chain](table, init, null) with Batchable {
+  casPart : CompareAndSetPart = Defaults.EmptyCompareAndSetPart,
+  override val consistencyLevel: ConsistencyLevel = null
+) extends Query[Table, Record, Limit, Order, Status, Chain](table, init, null) with Batchable {
 
   override protected[this] type QueryType[
     T <: CassandraTable[T, _],
@@ -66,8 +67,8 @@ class DeleteQuery[
     O <: OrderBound,
     S <: ConsistencyBound,
     C <: WhereBound
-  ](t: T, q: CQLQuery, r: Row => R): QueryType[T, R, L, O, S, C] = {
-    new DeleteQuery[T, R, L, O, S, C](t, q)
+  ](t: T, q: CQLQuery, r: Row => R, consistencyLevel: ConsistencyLevel = null): QueryType[T, R, L, O, S, C] = {
+    new DeleteQuery[T, R, L, O, S, C](t, q, Defaults.EmptyWherePart, Defaults.EmptyCompareAndSetPart, consistencyLevel)
   }
 
   /**

--- a/phantom-dsl/src/main/scala/com/websudos/phantom/builder/query/SelectQuery.scala
+++ b/phantom-dsl/src/main/scala/com/websudos/phantom/builder/query/SelectQuery.scala
@@ -36,7 +36,7 @@ import scala.annotation.implicitNotFound
 import scala.concurrent.{ExecutionContext, Future => ScalaFuture }
 import scala.util.Try
 
-import com.datastax.driver.core.{Row, Session}
+import com.datastax.driver.core.{ConsistencyLevel, Row, Session}
 import com.twitter.util.{ Future => TwitterFuture}
 
 import com.websudos.phantom.CassandraTable
@@ -60,7 +60,8 @@ class SelectQuery[
   orderPart: OrderPart = Defaults.EmptyOrderPart,
   limitedPart: LimitedPart = Defaults.EmptyLimitPart,
   filteringPart: FilteringPart = Defaults.EmptyFilteringPart,
-  count: Boolean = false
+  count: Boolean = false,
+  override val consistencyLevel: ConsistencyLevel = null
 ) extends Query[Table, Record, Limit, Order, Status, Chain](table, qb = init, rowFunc) with ExecutableQuery[Table,
   Record, Limit] {
 
@@ -86,8 +87,18 @@ class SelectQuery[
     O <: OrderBound,
     S <: ConsistencyBound,
     C <: WhereBound
-  ](t: T, q: CQLQuery, r: Row => R): QueryType[T, R, L, O, S, C] = {
-    new SelectQuery[T, R, L, O, S, C](t, r, q)
+  ](t: T, q: CQLQuery, r: Row => R, level: ConsistencyLevel = null): QueryType[T, R, L, O, S, C] = {
+    new SelectQuery[T, R, L, O, S, C](
+      table = t,
+      rowFunc = r,
+      init = q,
+      wherePart = wherePart,
+      orderPart = orderPart,
+      limitedPart = limitedPart,
+      filteringPart = filteringPart,
+      count = count,
+      consistencyLevel = level
+    )
   }
 
   def allowFiltering(): SelectQuery[Table, Record, Limit, Order, Status, Chain] = {
@@ -99,7 +110,8 @@ class SelectQuery[
       orderPart = orderPart,
       limitedPart = limitedPart,
       filteringPart = filteringPart append QueryBuilder.Select.allowFiltering(),
-      count = count
+      count = count,
+      consistencyLevel
     )
   }
 
@@ -120,7 +132,8 @@ class SelectQuery[
       orderPart = orderPart,
       limitedPart = limitedPart,
       filteringPart = filteringPart,
-      count = count
+      count = count,
+      consistencyLevel
     )
   }
 
@@ -140,7 +153,8 @@ class SelectQuery[
       orderPart = orderPart,
       limitedPart = limitedPart,
       filteringPart = filteringPart,
-      count = count
+      count = count,
+      consistencyLevel
     )
   }
 
@@ -154,15 +168,25 @@ class SelectQuery[
       orderPart = orderPart,
       limitedPart = limitedPart append QueryBuilder.limit(limit),
       filteringPart = filteringPart,
-      count = count
+      count = count,
+      consistencyLevel
     )
   }
 
 
   @implicitNotFound("You have already defined an ordering clause on this query.")
   final def orderBy(clause: Table => OrderingClause.Condition)(implicit ev: Order =:= Unordered): SelectQuery[Table, Record, Limit, Ordered, Status, Chain] = {
-    val query = QueryBuilder.Select.Ordering.orderBy(clause(table).qb)
-    new SelectQuery(table, rowFunc, init, wherePart, orderPart append query, limitedPart, filteringPart, count)
+    new SelectQuery(
+      table,
+      rowFunc,
+      init,
+      wherePart,
+      orderPart append QueryBuilder.Select.Ordering.orderBy(clause(table).qb),
+      limitedPart,
+      filteringPart,
+      count,
+      consistencyLevel
+    )
   }
 
   /**
@@ -183,7 +207,8 @@ class SelectQuery[
       orderPart = orderPart,
       limitedPart = enforceLimit,
       filteringPart = filteringPart,
-      count = count
+      count = count,
+      consistencyLevel
     ).singleFetch()
 
   }
@@ -206,7 +231,8 @@ class SelectQuery[
       orderPart = orderPart,
       limitedPart = enforceLimit,
       filteringPart = filteringPart,
-      count = count
+      count = count,
+      consistencyLevel
     ).singleCollect()
   }
 }

--- a/phantom-dsl/src/main/scala/com/websudos/phantom/builder/query/SelectQuery.scala
+++ b/phantom-dsl/src/main/scala/com/websudos/phantom/builder/query/SelectQuery.scala
@@ -62,7 +62,7 @@ class SelectQuery[
   filteringPart: FilteringPart = Defaults.EmptyFilteringPart,
   count: Boolean = false,
   override val consistencyLevel: ConsistencyLevel = null
-) extends Query[Table, Record, Limit, Order, Status, Chain](table, qb = init, rowFunc) with ExecutableQuery[Table,
+) extends Query[Table, Record, Limit, Order, Status, Chain](table, qb = init, rowFunc, consistencyLevel) with ExecutableQuery[Table,
   Record, Limit] {
 
   def fromRow(row: Row): Record = rowFunc(row)

--- a/phantom-dsl/src/main/scala/com/websudos/phantom/builder/query/TruncateQuery.scala
+++ b/phantom-dsl/src/main/scala/com/websudos/phantom/builder/query/TruncateQuery.scala
@@ -29,15 +29,27 @@
  */
 package com.websudos.phantom.builder.query
 
+import com.datastax.driver.core.{ProtocolVersion, Session, ConsistencyLevel}
 import com.websudos.phantom.CassandraTable
-import com.websudos.phantom.builder.{QueryBuilder, Unspecified, ConsistencyBound}
+import com.websudos.phantom.builder.{Specified, QueryBuilder, Unspecified, ConsistencyBound}
 import com.websudos.phantom.connectors.KeySpace
 
 class TruncateQuery[
   Table <: CassandraTable[Table, _],
   Record,
   Status <: ConsistencyBound
-](table: Table, val qb: CQLQuery) extends ExecutableStatement
+](table: Table, val qb: CQLQuery, override val consistencyLevel: ConsistencyLevel = null) extends ExecutableStatement {
+
+  def consistencyLevel_=(level: ConsistencyLevel)(implicit session: Session): TruncateQuery[Table, Record, Specified] = {
+    val protocol = session.getCluster.getConfiguration.getProtocolOptions.getProtocolVersionEnum
+
+    if (protocol.compareTo(ProtocolVersion.V2) == 1) {
+      new TruncateQuery(table, qb, level)
+    } else {
+      new TruncateQuery(table, QueryBuilder.consistencyLevel(qb, level.toString))
+    }
+  }
+}
 
 
 object TruncateQuery {

--- a/phantom-dsl/src/test/scala/com/websudos/phantom/builder/query/db/specialized/ConsistencyLevelTests.scala
+++ b/phantom-dsl/src/test/scala/com/websudos/phantom/builder/query/db/specialized/ConsistencyLevelTests.scala
@@ -78,7 +78,11 @@ class ConsistencyLevelTests extends PhantomCassandraTestSuite {
   it should "set a custom consistency level of QUORUM in a TRUNCATE query" in {
     val st = Primitives.truncate.consistencyLevel_=(ConsistencyLevel.QUORUM).statement
 
-    st.getConsistencyLevel shouldEqual ConsistencyLevel.QUORUM
+    if (protocol.compareTo(ProtocolVersion.V2) == 1) {
+      st.getConsistencyLevel shouldEqual ConsistencyLevel.QUORUM
+    } else {
+      st.getConsistencyLevel shouldEqual null
+    }
   }
 
   it should "set a custom consistency level of QUORUM in a CREATE query" in {

--- a/phantom-dsl/src/test/scala/com/websudos/phantom/builder/query/db/specialized/ConsistencyLevelTests.scala
+++ b/phantom-dsl/src/test/scala/com/websudos/phantom/builder/query/db/specialized/ConsistencyLevelTests.scala
@@ -1,0 +1,100 @@
+package com.websudos.phantom.builder.query.db.specialized
+
+import com.websudos.phantom.tables.{Primitives, Primitive}
+import com.websudos.phantom.testkit._
+import com.websudos.util.testing._
+import com.websudos.phantom.dsl._
+
+class ConsistencyLevelTests extends PhantomCassandraTestSuite {
+
+  it should "set a custom consistency level of ONE" in {
+    val row = gen[Primitive]
+
+    val st = Primitives.delete.where(_.pkey eqs row.pkey).consistencyLevel_=(ConsistencyLevel.ONE).statement
+
+    st.getConsistencyLevel shouldEqual ConsistencyLevel.ONE
+
+    val chain = for {
+      store <- Primitives.store(row).future()
+      inserted <- Primitives.select.where(_.pkey eqs row.pkey).one()
+      delete <- Primitives.delete.where(_.pkey eqs row.pkey).consistencyLevel_=(ConsistencyLevel.ONE).future()
+      deleted <- Primitives.select.where(_.pkey eqs row.pkey).one
+    } yield (inserted, deleted, delete)
+
+    chain successful {
+      r => {
+        r._1.isDefined shouldEqual true
+        r._1.get shouldEqual row
+
+        r._2.isEmpty shouldEqual true
+        r._3.wasApplied() shouldEqual true
+      }
+    }
+  }
+
+  it should "set a custom consistency level of LOCAL_ONE in a DELETE query" in {
+    val row = gen[Primitive]
+
+    val st = Primitives.delete.where(_.pkey eqs row.pkey).consistencyLevel_=(ConsistencyLevel.LOCAL_ONE).statement
+
+    st.getConsistencyLevel shouldEqual ConsistencyLevel.LOCAL_ONE
+
+    val chain = for {
+      store <- Primitives.store(row).future()
+      inserted <- Primitives.select.where(_.pkey eqs row.pkey).one()
+      delete <- Primitives.delete.where(_.pkey eqs row.pkey).consistencyLevel_=(ConsistencyLevel.LOCAL_ONE).future()
+      deleted <- Primitives.select.where(_.pkey eqs row.pkey).one
+    } yield (inserted, deleted, delete)
+
+    chain successful {
+      r => {
+        r._1.isDefined shouldEqual true
+        r._1.get shouldEqual row
+
+        r._2.isEmpty shouldEqual true
+        r._3.wasApplied() shouldEqual true
+      }
+    }
+
+  }
+
+  it should "set a custom consistency level of EACH_QUORUM in a SELECT query" in {
+    val row = gen[Primitive]
+
+    val st = Primitives.select.where(_.pkey eqs row.pkey)
+      .consistencyLevel_=(ConsistencyLevel.EACH_QUORUM).statement
+
+    st.getConsistencyLevel shouldEqual ConsistencyLevel.EACH_QUORUM
+  }
+
+  it should "set a custom consistency level of LOCAL_ONE in an UPDATE query" in {
+    val row = gen[Primitive]
+
+    val st = Primitives.update.where(_.pkey eqs row.pkey)
+      .consistencyLevel_=(ConsistencyLevel.LOCAL_ONE).statement
+
+    st.getConsistencyLevel shouldEqual ConsistencyLevel.LOCAL_ONE
+  }
+
+  it should "set a custom consistency level of QUORUM in an INSERT query" in {
+    val row = gen[Primitive]
+
+    val st = Primitives.store(row).consistencyLevel_=(ConsistencyLevel.QUORUM).statement
+
+    st.getConsistencyLevel shouldEqual ConsistencyLevel.QUORUM
+  }
+
+  it should "set a custom consistency level of QUORUM in a TRUNCATE query" in {
+    val st = Primitives.truncate.consistencyLevel_=(ConsistencyLevel.QUORUM).statement
+
+    st.getConsistencyLevel shouldEqual ConsistencyLevel.QUORUM
+  }
+
+  it should "set a custom consistency level of QUORUM in a CREATE query" in {
+    val st = Primitives.create.ifNotExists()
+      .consistencyLevel_=(ConsistencyLevel.LOCAL_QUORUM).statement
+
+    st.getConsistencyLevel shouldEqual ConsistencyLevel.LOCAL_QUORUM
+  }
+
+}

--- a/phantom-dsl/src/test/scala/com/websudos/phantom/builder/query/db/specialized/ConsistencyLevelTests.scala
+++ b/phantom-dsl/src/test/scala/com/websudos/phantom/builder/query/db/specialized/ConsistencyLevelTests.scala
@@ -1,11 +1,14 @@
 package com.websudos.phantom.builder.query.db.specialized
 
+import com.datastax.driver.core.ProtocolVersion
 import com.websudos.phantom.tables.{Primitives, Primitive}
 import com.websudos.phantom.testkit._
 import com.websudos.util.testing._
 import com.websudos.phantom.dsl._
 
 class ConsistencyLevelTests extends PhantomCassandraTestSuite {
+
+  val protocol = session.getCluster.getConfiguration.getProtocolOptions.getProtocolVersionEnum
 
   it should "set a custom consistency level of ONE" in {
     val row = gen[Primitive]
@@ -64,7 +67,11 @@ class ConsistencyLevelTests extends PhantomCassandraTestSuite {
     val st = Primitives.select.where(_.pkey eqs row.pkey)
       .consistencyLevel_=(ConsistencyLevel.EACH_QUORUM).statement
 
-    st.getConsistencyLevel shouldEqual ConsistencyLevel.EACH_QUORUM
+    if (protocol.compareTo(ProtocolVersion.V2) == 1) {
+      st.getConsistencyLevel shouldEqual ConsistencyLevel.EACH_QUORUM
+    } else {
+      st.getConsistencyLevel shouldEqual null
+    }
   }
 
   it should "set a custom consistency level of LOCAL_ONE in an UPDATE query" in {
@@ -73,7 +80,12 @@ class ConsistencyLevelTests extends PhantomCassandraTestSuite {
     val st = Primitives.update.where(_.pkey eqs row.pkey)
       .consistencyLevel_=(ConsistencyLevel.LOCAL_ONE).statement
 
-    st.getConsistencyLevel shouldEqual ConsistencyLevel.LOCAL_ONE
+    if (protocol.compareTo(ProtocolVersion.V2) == 1) {
+      st.getConsistencyLevel shouldEqual ConsistencyLevel.LOCAL_ONE
+    } else {
+      st.getConsistencyLevel shouldEqual null
+    }
+
   }
 
   it should "set a custom consistency level of QUORUM in an INSERT query" in {
@@ -81,7 +93,11 @@ class ConsistencyLevelTests extends PhantomCassandraTestSuite {
 
     val st = Primitives.store(row).consistencyLevel_=(ConsistencyLevel.QUORUM).statement
 
-    st.getConsistencyLevel shouldEqual ConsistencyLevel.QUORUM
+    if (protocol.compareTo(ProtocolVersion.V2) == 1) {
+      st.getConsistencyLevel shouldEqual ConsistencyLevel.QUORUM
+    } else {
+      st.getConsistencyLevel shouldEqual null
+    }
   }
 
   it should "set a custom consistency level of QUORUM in a TRUNCATE query" in {
@@ -94,7 +110,11 @@ class ConsistencyLevelTests extends PhantomCassandraTestSuite {
     val st = Primitives.create.ifNotExists()
       .consistencyLevel_=(ConsistencyLevel.LOCAL_QUORUM).statement
 
-    st.getConsistencyLevel shouldEqual ConsistencyLevel.LOCAL_QUORUM
+    if (protocol.compareTo(ProtocolVersion.V2) == 1) {
+      st.getConsistencyLevel shouldEqual ConsistencyLevel.LOCAL_QUORUM
+    } else {
+      st.getConsistencyLevel shouldEqual null
+    }
   }
 
 }

--- a/phantom-dsl/src/test/scala/com/websudos/phantom/builder/query/db/specialized/ConsistencyLevelTests.scala
+++ b/phantom-dsl/src/test/scala/com/websudos/phantom/builder/query/db/specialized/ConsistencyLevelTests.scala
@@ -15,24 +15,12 @@ class ConsistencyLevelTests extends PhantomCassandraTestSuite {
 
     val st = Primitives.delete.where(_.pkey eqs row.pkey).consistencyLevel_=(ConsistencyLevel.ONE).statement
 
-    st.getConsistencyLevel shouldEqual ConsistencyLevel.ONE
-
-    val chain = for {
-      store <- Primitives.store(row).future()
-      inserted <- Primitives.select.where(_.pkey eqs row.pkey).one()
-      delete <- Primitives.delete.where(_.pkey eqs row.pkey).consistencyLevel_=(ConsistencyLevel.ONE).future()
-      deleted <- Primitives.select.where(_.pkey eqs row.pkey).one
-    } yield (inserted, deleted, delete)
-
-    chain successful {
-      r => {
-        r._1.isDefined shouldEqual true
-        r._1.get shouldEqual row
-
-        r._2.isEmpty shouldEqual true
-        r._3.wasApplied() shouldEqual true
-      }
+    if (protocol.compareTo(ProtocolVersion.V2) == 1) {
+      st.getConsistencyLevel shouldEqual ConsistencyLevel.ONE
+    } else {
+      st.getConsistencyLevel shouldEqual null
     }
+
   }
 
   it should "set a custom consistency level of LOCAL_ONE in a DELETE query" in {
@@ -40,23 +28,10 @@ class ConsistencyLevelTests extends PhantomCassandraTestSuite {
 
     val st = Primitives.delete.where(_.pkey eqs row.pkey).consistencyLevel_=(ConsistencyLevel.LOCAL_ONE).statement
 
-    st.getConsistencyLevel shouldEqual ConsistencyLevel.LOCAL_ONE
-
-    val chain = for {
-      store <- Primitives.store(row).future()
-      inserted <- Primitives.select.where(_.pkey eqs row.pkey).one()
-      delete <- Primitives.delete.where(_.pkey eqs row.pkey).consistencyLevel_=(ConsistencyLevel.LOCAL_ONE).future()
-      deleted <- Primitives.select.where(_.pkey eqs row.pkey).one
-    } yield (inserted, deleted, delete)
-
-    chain successful {
-      r => {
-        r._1.isDefined shouldEqual true
-        r._1.get shouldEqual row
-
-        r._2.isEmpty shouldEqual true
-        r._3.wasApplied() shouldEqual true
-      }
+    if (protocol.compareTo(ProtocolVersion.V2) == 1) {
+      st.getConsistencyLevel shouldEqual ConsistencyLevel.LOCAL_ONE
+    } else {
+      st.getConsistencyLevel shouldEqual null
     }
 
   }

--- a/phantom-dsl/src/test/scala/com/websudos/phantom/builder/serializers/UpdateQuerySerializationTest.scala
+++ b/phantom-dsl/src/test/scala/com/websudos/phantom/builder/serializers/UpdateQuerySerializationTest.scala
@@ -1,6 +1,6 @@
 package com.websudos.phantom.builder.serializers
 
-import com.datastax.driver.core.ConsistencyLevel
+import com.datastax.driver.core.{ProtocolVersion, ConsistencyLevel}
 import com.websudos.phantom.builder.query.QueryBuilderTest
 import com.websudos.phantom.connectors.KeySpace
 import com.websudos.phantom.tables.Recipes
@@ -11,6 +11,8 @@ import com.websudos.util.testing._
 class UpdateQuerySerializationTest extends QueryBuilderTest with PhantomCassandraConnector {
 
   override implicit val keySpace = KeySpace("phantom")
+
+  val protocol = session.getCluster.getConfiguration.getProtocolOptions.getProtocolVersionEnum
 
   "An Update query should" - {
     "allow specifying consistency levels" - {
@@ -24,8 +26,11 @@ class UpdateQuerySerializationTest extends QueryBuilderTest with PhantomCassandr
           .consistencyLevel_=(ConsistencyLevel.ALL)
           .queryString
 
-        query shouldEqual s"UPDATE phantom.Recipes SET servings = 5 WHERE url = '$url'"
-
+        if (protocol.compareTo(ProtocolVersion.V2) == 1) {
+          query shouldEqual s"UPDATE phantom.Recipes SET servings = 5 WHERE url = '$url'"
+        } else {
+          query shouldEqual s"UPDATE phantom.Recipes USING CONSISTENCY ALL SET servings = 5 WHERE url = '$url'"
+        }
       }
 
       "specify a consistency level in a ConditionUpdateQuery" in {
@@ -38,8 +43,11 @@ class UpdateQuerySerializationTest extends QueryBuilderTest with PhantomCassandr
           .consistencyLevel_=(ConsistencyLevel.ALL)
           .queryString
 
-        query shouldEqual s"UPDATE phantom.Recipes SET servings = 5 WHERE url = '$url' IF description = 'test'"
-
+        if (protocol.compareTo(ProtocolVersion.V2) == 1) {
+          query shouldEqual s"UPDATE phantom.Recipes SET servings = 5 WHERE url = '$url' IF description = 'test'"
+        } else {
+          query shouldEqual s"UPDATE phantom.Recipes USING CONSISTENCY ALL SET servings = 5 WHERE url = '$url' IF description = 'test'"
+        }
       }
     }
   }

--- a/phantom-dsl/src/test/scala/com/websudos/phantom/builder/serializers/UpdateQuerySerializationTest.scala
+++ b/phantom-dsl/src/test/scala/com/websudos/phantom/builder/serializers/UpdateQuerySerializationTest.scala
@@ -2,11 +2,15 @@ package com.websudos.phantom.builder.serializers
 
 import com.datastax.driver.core.ConsistencyLevel
 import com.websudos.phantom.builder.query.QueryBuilderTest
+import com.websudos.phantom.connectors.KeySpace
 import com.websudos.phantom.tables.Recipes
 import com.websudos.phantom.dsl._
+import com.websudos.phantom.testkit.suites.PhantomCassandraConnector
 import com.websudos.util.testing._
 
-class UpdateQuerySerializationTest extends QueryBuilderTest {
+class UpdateQuerySerializationTest extends QueryBuilderTest with PhantomCassandraConnector {
+
+  override implicit val keySpace = KeySpace("phantom")
 
   "An Update query should" - {
     "allow specifying consistency levels" - {
@@ -20,7 +24,7 @@ class UpdateQuerySerializationTest extends QueryBuilderTest {
           .consistencyLevel_=(ConsistencyLevel.ALL)
           .queryString
 
-        query shouldEqual s"UPDATE phantom.Recipes USING CONSISTENCY ALL SET servings = 5 WHERE url = '$url'"
+        query shouldEqual s"UPDATE phantom.Recipes SET servings = 5 WHERE url = '$url'"
 
       }
 
@@ -34,7 +38,7 @@ class UpdateQuerySerializationTest extends QueryBuilderTest {
           .consistencyLevel_=(ConsistencyLevel.ALL)
           .queryString
 
-        query shouldEqual s"UPDATE phantom.Recipes USING CONSISTENCY ALL SET servings = 5 WHERE url = '$url' IF description = 'test'"
+        query shouldEqual s"UPDATE phantom.Recipes SET servings = 5 WHERE url = '$url' IF description = 'test'"
 
       }
     }

--- a/phantom-udt/src/main/scala/com/websudos/phantom/udt/UDTColumn.scala
+++ b/phantom-udt/src/main/scala/com/websudos/phantom/udt/UDTColumn.scala
@@ -31,7 +31,7 @@ package com.websudos.phantom.udt
 
 import java.util.Date
 
-import com.datastax.driver.core.{ResultSet, Row, Session, UDTValue, UserType}
+import com.datastax.driver.core._
 import com.twitter.util.Future
 import com.websudos.phantom.CassandraTable
 import com.websudos.phantom.builder.primitives.Primitive
@@ -223,11 +223,11 @@ abstract class UDTColumn[
 sealed class UDTCreateQuery(val qb: CQLQuery, udt: UDTDefinition[_]) extends ExecutableStatement {
 
   override def execute()(implicit session: Session, keySpace: KeySpace): Future[ResultSet] = {
-    twitterQueryStringExecuteToFuture(udt.schema())
+    twitterQueryStringExecuteToFuture(new SimpleStatement(udt.schema()))
   }
 
   override def future()(implicit session: Session, keySpace: KeySpace): ScalaFuture[ResultSet] = {
-    scalaQueryStringExecuteToFuture(udt.schema())
+    scalaQueryStringExecuteToFuture(new SimpleStatement(udt.schema()))
   }
 }
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -102,7 +102,7 @@ object Build extends Build {
 
   val sharedSettings: Seq[Def.Setting[_]] = Defaults.coreDefaultSettings ++ Seq(
     organization := "com.websudos",
-    version := "1.10.6",
+    version := "1.11.0",
     scalaVersion := "2.11.7",
     crossScalaVersions := Seq("2.10.5", "2.11.7"),
     resolvers ++= Seq(


### PR DESCRIPTION
…L protocol V3.

- Adding per-protocol version logic to specify consistency levels.
- Version 2 and below consistency is specified in an `USING` clause by phantom.
- Consistency levels for V3 of the protocol are simply being forwarded to the Datastax Java Driver via `SimpleStatement` to allow the driver to set the level internally outside of phantom.
- `consistencyLevel` argument is now propagated everywhere.
- Added tests to make sure the consistency level is propagated in settings when the latest protocol is used.
