### PR TITLE
Fixing support for consistency levels.

### DIFF
--- a/phantom-dsl/src/main/scala/com/websudos/phantom/builder/query/CassandraOperations.scala
+++ b/phantom-dsl/src/main/scala/com/websudos/phantom/builder/query/CassandraOperations.scala
@@ -29,7 +29,7 @@
  */
 package com.websudos.phantom.builder.query
 
-import com.datastax.driver.core.{ResultSet, Session}
+import com.datastax.driver.core.{ResultSet, Session, Statement}
 import com.google.common.util.concurrent.{FutureCallback, Futures}
 import com.twitter.util.{Future => TwitterFuture, Promise => TwitterPromise, Return, Throw}
 import com.websudos.phantom.Manager
@@ -40,16 +40,16 @@ import scala.util.{Failure, Success}
 
 private[phantom] trait CassandraOperations {
 
-  protected[this] def scalaQueryStringExecuteToFuture(query: String)(implicit session: Session, keyspace: KeySpace): ScalaFuture[ResultSet] = {
-    scalaQueryStringToPromise(query).future
+  protected[this] def scalaQueryStringExecuteToFuture(st: Statement)(implicit session: Session, keyspace: KeySpace): ScalaFuture[ResultSet] = {
+    scalaQueryStringToPromise(st).future
   }
 
-  protected[this] def scalaQueryStringToPromise(query: String)(implicit session: Session, keyspace: KeySpace): ScalaPromise[ResultSet] = {
-    Manager.logger.debug(s"Executing query: $query")
+  protected[this] def scalaQueryStringToPromise(st: Statement)(implicit session: Session, keyspace: KeySpace): ScalaPromise[ResultSet] = {
+    Manager.logger.debug(s"Executing query: ${st}")
 
     val promise = ScalaPromise[ResultSet]()
 
-    val future = session.executeAsync(query)
+    val future = session.executeAsync(st)
 
     val callback = new FutureCallback[ResultSet] {
       def onSuccess(result: ResultSet): Unit = {
@@ -66,9 +66,9 @@ private[phantom] trait CassandraOperations {
   }
 
 
-  protected[this] def twitterQueryStringExecuteToFuture(query: String)(implicit session: Session, keyspace: KeySpace): TwitterFuture[ResultSet] = {
+  protected[this] def twitterQueryStringExecuteToFuture(str: Statement)(implicit session: Session, keyspace: KeySpace): TwitterFuture[ResultSet] = {
     val promise = TwitterPromise[ResultSet]()
-    val future = session.executeAsync(query)
+    val future = session.executeAsync(str)
 
     val callback = new FutureCallback[ResultSet] {
       def onSuccess(result: ResultSet): Unit = {

--- a/phantom-dsl/src/main/scala/com/websudos/phantom/builder/query/CreateQuery.scala
+++ b/phantom-dsl/src/main/scala/com/websudos/phantom/builder/query/CreateQuery.scala
@@ -29,17 +29,15 @@
  */
 package com.websudos.phantom.builder.query
 
-import com.datastax.driver.core.{ResultSet, Session}
-import com.twitter.util.{Await => TwitterAwait, Future => TwitterFuture}
+import com.datastax.driver.core._
+import com.twitter.util.{Future => TwitterFuture}
 import com.websudos.phantom.builder._
 import com.websudos.phantom.builder.syntax.CQLSyntax
 import com.websudos.phantom.connectors.KeySpace
 import com.websudos.phantom.{CassandraTable, Manager}
 
 import scala.annotation.implicitNotFound
-import scala.concurrent.{Await => ScalaAwait, ExecutionContext, Future => ScalaFuture}
-
-
+import scala.concurrent.{ ExecutionContext, Future => ScalaFuture}
 
 class RootCreateQuery[
   Table <: CassandraTable[Table, _],
@@ -95,7 +93,22 @@ class CreateQuery[
   Table <: CassandraTable[Table, _],
   Record,
   Status <: ConsistencyBound
-](table: Table, val init: CQLQuery, val withClause: WithPart) extends ExecutableStatement {
+](
+  table: Table,
+  val init: CQLQuery,
+  val withClause: WithPart,
+  override val consistencyLevel: ConsistencyLevel = null
+) extends ExecutableStatement {
+
+  def consistencyLevel_=(level: ConsistencyLevel)(implicit session: Session): CreateQuery[Table, Record, Specified] = {
+    val protocol = session.getCluster.getConfiguration.getProtocolOptions.getProtocolVersionEnum
+
+    if (protocol.compareTo(ProtocolVersion.V2) == 1) {
+      new CreateQuery(table, qb, withClause, level)
+    } else {
+      new CreateQuery(table, QueryBuilder.consistencyLevel(qb, level.toString), withClause)
+    }
+  }
 
   @implicitNotFound("You cannot use 2 `with` clauses on the same create query. Use `and` instead.")
   final def `with`(clause: TablePropertyClause): CreateQuery[Table, Record, Status] = {
@@ -103,13 +116,15 @@ class CreateQuery[
       new CreateQuery(
         table,
         init,
-        withClause append QueryBuilder.Create.`with`(clause.qb)
+        withClause append QueryBuilder.Create.`with`(clause.qb),
+        consistencyLevel
       )
     } else {
       new CreateQuery(
         table,
         init,
-        withClause append QueryBuilder.Update.and(clause.qb)
+        withClause append QueryBuilder.Update.and(clause.qb),
+        consistencyLevel
       )
     }
   }
@@ -152,13 +167,11 @@ class CreateQuery[
     implicit val ex: ExecutionContext = Manager.scalaExecutor
 
     if (table.secondaryKeys.isEmpty) {
-      scalaQueryStringExecuteToFuture(qb.terminate().queryString)
+      scalaQueryStringExecuteToFuture(new SimpleStatement(qb.terminate().queryString))
     } else {
-
       super.future() flatMap {
         res => {
-
-          val indexes = table.secondaryKeys map {
+          val indexes = new ExecutableStatementList(table.secondaryKeys map {
             key => {
 
               val query = if(key.isMapKeyIndex) {
@@ -166,13 +179,12 @@ class CreateQuery[
               } else {
                 QueryBuilder.Create.index(table.tableName, keySpace.name, key.name)
               }
-
-              scalaQueryStringExecuteToFuture(query.queryString)
+              query
             }
-          }
+          })
 
-          Manager.logger.debug(s"Creating ${indexes.size} indexes on ${QueryBuilder.keyspace(keySpace.name, table.tableName).queryString}")
-          ScalaFuture.sequence(indexes) map { _ => res }
+          Manager.logger.debug(s"Creating ${indexes.list.size} indexes on ${QueryBuilder.keyspace(keySpace.name, table.tableName).queryString}")
+          indexes.future() map { _ => res }
         }
       }
     }
@@ -181,27 +193,24 @@ class CreateQuery[
   override def execute()(implicit session: Session, keySpace: KeySpace): TwitterFuture[ResultSet] = {
 
     if (table.secondaryKeys.isEmpty) {
-      twitterQueryStringExecuteToFuture(qb.terminate().queryString)
+      twitterQueryStringExecuteToFuture(new SimpleStatement(qb.terminate().queryString))
     } else {
 
       super.execute() flatMap {
         res => {
 
-          val indexes = table.secondaryKeys map {
+          val indexes = new ExecutableStatementList(table.secondaryKeys map {
             key => {
-
-              val query = if(key.isMapKeyIndex) {
+               if(key.isMapKeyIndex) {
                 QueryBuilder.Create.mapIndex(table.tableName, keySpace.name, key.name)
               } else {
                 QueryBuilder.Create.index(table.tableName, keySpace.name, key.name)
               }
-
-              twitterQueryStringExecuteToFuture(query.queryString)
             }
-          }
+          })
 
-          Manager.logger.debug(s"Creating ${indexes.size} indexes on ${QueryBuilder.keyspace(keySpace.name, table.tableName).queryString}")
-          TwitterFuture.collect(indexes) map {_ => res}
+          Manager.logger.debug(s"Creating ${indexes.list.size} indexes on ${QueryBuilder.keyspace(keySpace.name, table.tableName).queryString}")
+          indexes.execute() map {_ => res}
         }
       }
     }

--- a/phantom-dsl/src/main/scala/com/websudos/phantom/builder/query/DeleteQuery.scala
+++ b/phantom-dsl/src/main/scala/com/websudos/phantom/builder/query/DeleteQuery.scala
@@ -29,7 +29,7 @@
  */
 package com.websudos.phantom.builder.query
 
-import com.datastax.driver.core.Row
+import com.datastax.driver.core.{ConsistencyLevel, Row}
 import com.websudos.phantom.CassandraTable
 import com.websudos.phantom.builder._
 import com.websudos.phantom.builder.clauses.{CompareAndSetClause, WhereClause}
@@ -47,8 +47,9 @@ class DeleteQuery[
 ](table: Table,
   init: CQLQuery,
   wherePart : WherePart = Defaults.EmptyWherePart,
-  casPart : CompareAndSetPart = Defaults.EmptyCompareAndSetPart
-                    ) extends Query[Table, Record, Limit, Order, Status, Chain](table, init, null) with Batchable {
+  casPart : CompareAndSetPart = Defaults.EmptyCompareAndSetPart,
+  override val consistencyLevel: ConsistencyLevel = null
+) extends Query[Table, Record, Limit, Order, Status, Chain](table, init, null) with Batchable {
 
   override protected[this] type QueryType[
     T <: CassandraTable[T, _],
@@ -66,8 +67,8 @@ class DeleteQuery[
     O <: OrderBound,
     S <: ConsistencyBound,
     C <: WhereBound
-  ](t: T, q: CQLQuery, r: Row => R): QueryType[T, R, L, O, S, C] = {
-    new DeleteQuery[T, R, L, O, S, C](t, q)
+  ](t: T, q: CQLQuery, r: Row => R, consistencyLevel: ConsistencyLevel = null): QueryType[T, R, L, O, S, C] = {
+    new DeleteQuery[T, R, L, O, S, C](t, q, Defaults.EmptyWherePart, Defaults.EmptyCompareAndSetPart, consistencyLevel)
   }
 
   /**

--- a/phantom-dsl/src/main/scala/com/websudos/phantom/builder/query/TruncateQuery.scala
+++ b/phantom-dsl/src/main/scala/com/websudos/phantom/builder/query/TruncateQuery.scala
@@ -29,15 +29,27 @@
  */
 package com.websudos.phantom.builder.query
 
+import com.datastax.driver.core.{ProtocolVersion, Session, ConsistencyLevel}
 import com.websudos.phantom.CassandraTable
-import com.websudos.phantom.builder.{QueryBuilder, Unspecified, ConsistencyBound}
+import com.websudos.phantom.builder.{Specified, QueryBuilder, Unspecified, ConsistencyBound}
 import com.websudos.phantom.connectors.KeySpace
 
 class TruncateQuery[
   Table <: CassandraTable[Table, _],
   Record,
   Status <: ConsistencyBound
-](table: Table, val qb: CQLQuery) extends ExecutableStatement
+](table: Table, val qb: CQLQuery, override val consistencyLevel: ConsistencyLevel = null) extends ExecutableStatement {
+
+  def consistencyLevel_=(level: ConsistencyLevel)(implicit session: Session): TruncateQuery[Table, Record, Specified] = {
+    val protocol = session.getCluster.getConfiguration.getProtocolOptions.getProtocolVersionEnum
+
+    if (protocol.compareTo(ProtocolVersion.V2) == 1) {
+      new TruncateQuery(table, qb, level)
+    } else {
+      new TruncateQuery(table, QueryBuilder.consistencyLevel(qb, level.toString))
+    }
+  }
+}
 
 
 object TruncateQuery {

--- a/phantom-dsl/src/test/scala/com/websudos/phantom/builder/query/db/specialized/ConsistencyLevelTests.scala
+++ b/phantom-dsl/src/test/scala/com/websudos/phantom/builder/query/db/specialized/ConsistencyLevelTests.scala
@@ -1,0 +1,99 @@
+package com.websudos.phantom.builder.query.db.specialized
+
+import com.datastax.driver.core.ProtocolVersion
+import com.websudos.phantom.tables.{Primitives, Primitive}
+import com.websudos.phantom.testkit._
+import com.websudos.util.testing._
+import com.websudos.phantom.dsl._
+
+class ConsistencyLevelTests extends PhantomCassandraTestSuite {
+
+  val protocol = session.getCluster.getConfiguration.getProtocolOptions.getProtocolVersionEnum
+
+  it should "set a custom consistency level of ONE" in {
+    val row = gen[Primitive]
+
+    val st = Primitives.delete.where(_.pkey eqs row.pkey).consistencyLevel_=(ConsistencyLevel.ONE).statement
+
+    if (protocol.compareTo(ProtocolVersion.V2) == 1) {
+      st.getConsistencyLevel shouldEqual ConsistencyLevel.ONE
+    } else {
+      st.getConsistencyLevel shouldEqual null
+    }
+
+  }
+
+  it should "set a custom consistency level of LOCAL_ONE in a DELETE query" in {
+    val row = gen[Primitive]
+
+    val st = Primitives.delete.where(_.pkey eqs row.pkey).consistencyLevel_=(ConsistencyLevel.LOCAL_ONE).statement
+
+    if (protocol.compareTo(ProtocolVersion.V2) == 1) {
+      st.getConsistencyLevel shouldEqual ConsistencyLevel.LOCAL_ONE
+    } else {
+      st.getConsistencyLevel shouldEqual null
+    }
+
+  }
+
+  it should "set a custom consistency level of EACH_QUORUM in a SELECT query" in {
+    val row = gen[Primitive]
+
+    val st = Primitives.select.where(_.pkey eqs row.pkey)
+      .consistencyLevel_=(ConsistencyLevel.EACH_QUORUM).statement
+
+    if (protocol.compareTo(ProtocolVersion.V2) == 1) {
+      st.getConsistencyLevel shouldEqual ConsistencyLevel.EACH_QUORUM
+    } else {
+      st.getConsistencyLevel shouldEqual null
+    }
+  }
+
+  it should "set a custom consistency level of LOCAL_ONE in an UPDATE query" in {
+    val row = gen[Primitive]
+
+    val st = Primitives.update.where(_.pkey eqs row.pkey)
+      .consistencyLevel_=(ConsistencyLevel.LOCAL_ONE).statement
+
+    if (protocol.compareTo(ProtocolVersion.V2) == 1) {
+      st.getConsistencyLevel shouldEqual ConsistencyLevel.LOCAL_ONE
+    } else {
+      st.getConsistencyLevel shouldEqual null
+    }
+
+  }
+
+  it should "set a custom consistency level of QUORUM in an INSERT query" in {
+    val row = gen[Primitive]
+
+    val st = Primitives.store(row).consistencyLevel_=(ConsistencyLevel.QUORUM).statement
+
+    if (protocol.compareTo(ProtocolVersion.V2) == 1) {
+      st.getConsistencyLevel shouldEqual ConsistencyLevel.QUORUM
+    } else {
+      st.getConsistencyLevel shouldEqual null
+    }
+  }
+
+  it should "set a custom consistency level of QUORUM in a TRUNCATE query" in {
+    val st = Primitives.truncate.consistencyLevel_=(ConsistencyLevel.QUORUM).statement
+
+    if (protocol.compareTo(ProtocolVersion.V2) == 1) {
+      st.getConsistencyLevel shouldEqual ConsistencyLevel.QUORUM
+    } else {
+      st.getConsistencyLevel shouldEqual null
+    }
+  }
+
+  it should "set a custom consistency level of QUORUM in a CREATE query" in {
+    val st = Primitives.create.ifNotExists()
+      .consistencyLevel_=(ConsistencyLevel.LOCAL_QUORUM).statement
+
+    if (protocol.compareTo(ProtocolVersion.V2) == 1) {
+      st.getConsistencyLevel shouldEqual ConsistencyLevel.LOCAL_QUORUM
+    } else {
+      st.getConsistencyLevel shouldEqual null
+    }
+  }
+
+}

--- a/phantom-udt/src/main/scala/com/websudos/phantom/udt/UDTColumn.scala
+++ b/phantom-udt/src/main/scala/com/websudos/phantom/udt/UDTColumn.scala
@@ -31,7 +31,7 @@ package com.websudos.phantom.udt
 
 import java.util.Date
 
-import com.datastax.driver.core.{ResultSet, Row, Session, UDTValue, UserType}
+import com.datastax.driver.core._
 import com.twitter.util.Future
 import com.websudos.phantom.CassandraTable
 import com.websudos.phantom.builder.primitives.Primitive
@@ -223,11 +223,11 @@ abstract class UDTColumn[
 sealed class UDTCreateQuery(val qb: CQLQuery, udt: UDTDefinition[_]) extends ExecutableStatement {
 
   override def execute()(implicit session: Session, keySpace: KeySpace): Future[ResultSet] = {
-    twitterQueryStringExecuteToFuture(udt.schema())
+    twitterQueryStringExecuteToFuture(new SimpleStatement(udt.schema()))
   }
 
   override def future()(implicit session: Session, keySpace: KeySpace): ScalaFuture[ResultSet] = {
-    scalaQueryStringExecuteToFuture(udt.schema())
+    scalaQueryStringExecuteToFuture(new SimpleStatement(udt.schema()))
   }
 }
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -102,7 +102,7 @@ object Build extends Build {
 
   val sharedSettings: Seq[Def.Setting[_]] = Defaults.coreDefaultSettings ++ Seq(
     organization := "com.websudos",
-    version := "1.10.6",
+    version := "1.11.0",
     scalaVersion := "2.11.7",
     crossScalaVersions := Seq("2.10.5", "2.11.7"),
     resolvers ++= Seq(


### PR DESCRIPTION
- Adding per-protocol version logic to specify consistency levels.
- Version 2 and below consistency is specified in an `USING` clause by phantom.
- Consistency levels for V3 of the protocol are simply being forwarded to the Datastax Java Driver via `SimpleStatement` to allow the driver to set the level internally outside of phantom.
- `consistencyLevel` argument is now propagated everywhere.
- Added tests to make sure the consistency level is propagated in settings when the latest protocol is used.
- Adding conditional tests based on protocol version.