### PR TITLE
fix SelectQuery for casandra > V2

### DIFF
--- a/phantom-dsl/src/main/scala/com/websudos/phantom/builder/query/Query.scala
+++ b/phantom-dsl/src/main/scala/com/websudos/phantom/builder/query/Query.scala
@@ -99,7 +99,7 @@ abstract class Query[
   ](t: T, q: CQLQuery, r: Row => R, consistencyLevel: Option[ConsistencyLevel] = None): QueryType[T, R, L, O, S, C]
 
   @implicitNotFound("A ConsistencyLevel was already specified for this query.")
-  final def consistencyLevel_=(level: ConsistencyLevel)(implicit ev: Status =:= Unspecified, session: Session): QueryType[Table, Record, Limit, Order, Specified, Chain] = {
+  def consistencyLevel_=(level: ConsistencyLevel)(implicit ev: Status =:= Unspecified, session: Session): QueryType[Table, Record, Limit, Order, Specified, Chain] = {
     if (session.v3orNewer) {
       create[Table, Record, Limit, Order, Specified, Chain](table, qb, row, Some(level))
     } else {


### PR DESCRIPTION
For Cassandra > V2, if a SelectQuery with WHERE clause calls consistencyLevel_=, the WHERE clause will appear twice and rejected by Cassandra.