### PR TITLE
fix ProtocolVersion 'isNewerThan' check

### DIFF
--- a/phantom-dsl/src/main/scala/com/websudos/phantom/builder/query/CassandraOperations.scala
+++ b/phantom-dsl/src/main/scala/com/websudos/phantom/builder/query/CassandraOperations.scala
@@ -46,7 +46,7 @@ private[phantom] trait CassandraOperations {
     }
 
     def isNewerThan(pv: ProtocolVersion): Boolean = {
-      protocolVersion.compareTo(pv) == 1
+      protocolVersion.compareTo(pv) > 0
     }
 
     def v3orNewer : Boolean = isNewerThan(ProtocolVersion.V2)


### PR DESCRIPTION
`ProtocolVersion.compareTo` can return values greater than 1 (e.g. `V4.compareTo(V2) == 2`), so we should use `> 0` to tell if it's newer.

This caused problems for me on both latest versions of Cassandra (2.2.3 and 3.0.0) because it looks like both are reporting protocol version 4, which breaks the old check. Is Phantom not supported/tested on either of these releases?

Apologies if I'm completely off base here, I've just started playing with Cassandra, and particularly like Phantom's type-safe interface.