### PR TITLE
Fix "Codec not found for requested operation" issues (None and Some)

### DIFF
--- a/phantom-dsl/src/main/scala/com/websudos/phantom/builder/query/prepared/PreparedBuilder.scala
+++ b/phantom-dsl/src/main/scala/com/websudos/phantom/builder/query/prepared/PreparedBuilder.scala
@@ -119,17 +119,23 @@ trait PreparedFlattener {
     * @return A clansed set of parameters.
     */
   protected[this] def flattenOpt(parameters: Seq[Any]): Seq[AnyRef] = {
-    //noinspection ComparingUnrelatedTypes
-    parameters map {
-      case x if x.isInstanceOf[Some[_]] => x.asInstanceOf[Some[Any]].get
-      case x if x.isInstanceOf[List[_]] => x.asInstanceOf[List[Any]].asJava
-      case x if x.isInstanceOf[Set[_]] => x.asInstanceOf[Set[Any]].asJava
-      case x if x.isInstanceOf[Map[_, _]] => x.asInstanceOf[Map[Any, Any]].asJava
-      case x if x.isInstanceOf[DateTime] => x.asInstanceOf[DateTime].toDate
-      case x if x.isInstanceOf[Enumeration#Value] => x.asInstanceOf[Enumeration#Value].toString
-      case x if x.isInstanceOf[BigDecimal] => x.asInstanceOf[BigDecimal].bigDecimal
-      case x => x
-    } map(_.asInstanceOf[AnyRef])
+
+    def flattenOpt(param: Any): Any = {
+      //noinspection ComparingUnrelatedTypes
+      param match {
+        case x if x.isInstanceOf[Some[_]] => flattenOpt(x.asInstanceOf[Some[Any]].get)
+        case x if x.isInstanceOf[None.type] => null.asInstanceOf[Any]
+        case x if x.isInstanceOf[List[_]] => x.asInstanceOf[List[Any]].asJava
+        case x if x.isInstanceOf[Set[_]] => x.asInstanceOf[Set[Any]].asJava
+        case x if x.isInstanceOf[Map[_, _]] => x.asInstanceOf[Map[Any, Any]].asJava
+        case x if x.isInstanceOf[DateTime] => x.asInstanceOf[DateTime].toDate
+        case x if x.isInstanceOf[Enumeration#Value] => x.asInstanceOf[Enumeration#Value].toString
+        case x if x.isInstanceOf[BigDecimal] => x.asInstanceOf[BigDecimal].bigDecimal
+        case x => x
+      }
+    }
+
+    parameters map flattenOpt map(_.asInstanceOf[AnyRef])
   }
 }
 


### PR DESCRIPTION
Fix "Codec not found for requested operation" issues:
- [varchar <-> scala.None$]
- Apply the codec mapping on the content of Some[T]. For example: Some[DateTime] now has flattenOpt applied on its content, mapping DateTime to Date. This has been achieved by extracting the the codec mapping to an internal function (flattenOpt(param: Any)) so that it can be called recursively. Note that something similar should be applied to List, Set and Map, but we have not tackled it yet.



