### PR TITLE
Corrected cql type for LocalDate and Date accessor method

### DIFF
--- a/phantom-dsl/src/main/scala/com/websudos/phantom/builder/primitives/Primitive.scala
+++ b/phantom-dsl/src/main/scala/com/websudos/phantom/builder/primitives/Primitive.scala
@@ -195,7 +195,7 @@ trait DefaultPrimitives {
     val cassandraType = CQLSyntax.Types.Timestamp
 
     def fromRow(row: Row, name: String): Option[Date] =
-      if (row.isNull(name)) None else Try(new Date(row.getDate(name).getMillisSinceEpoch)).toOption
+      if (row.isNull(name)) None else Try(row.getTimestamp(name)).toOption
 
     override def asCql(value: Date): String = {
       DateSerializer.asCql(value)
@@ -212,12 +212,11 @@ trait DefaultPrimitives {
     override def clz: Class[Date] = classOf[Date]
   }
 
-
   implicit object LocalDateIsPrimitive extends Primitive[LocalDate] {
 
     override type PrimitiveType = com.datastax.driver.core.LocalDate
 
-    val cassandraType = CQLSyntax.Types.Timestamp
+    val cassandraType = CQLSyntax.Types.Date
 
     def fromRow(row: Row, name: String): Option[LocalDate] =
       if (row.isNull(name)) None else Try(row.getDate(name)).toOption

--- a/phantom-dsl/src/main/scala/com/websudos/phantom/builder/syntax/CQLSyntax.scala
+++ b/phantom-dsl/src/main/scala/com/websudos/phantom/builder/syntax/CQLSyntax.scala
@@ -164,6 +164,7 @@ object CQLSyntax {
     val Blob = "blob"
     val Boolean = "boolean"
     val Counter = "counter"
+    val Date = "date"
     val Decimal = "decimal"
     val Double = "double"
     val Long = "long"


### PR DESCRIPTION
According to http://docs.datastax.com/en/developer/java-driver/3.0/java-driver/reference/javaClass2Cql3Datatypes.html `com.datastax.driver.core.LocalDate` type is for cql `date`and `getTimestamp` is appropriate for `timestamp` type.